### PR TITLE
ci: publish crates from version tags

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,102 @@
+name: Publish crates
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Update Rust toolchain
+        run: rustup update stable
+
+      - name: Verify tag matches package versions
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          mapfile -t package_versions < <(
+            cargo metadata --no-deps --format-version 1 |
+              jq -r '
+                .workspace_members as $members
+                | [.packages[]
+                    | select(.id as $id | $members | index($id))
+                    | select(.publish != [])
+                    | .version]
+                | unique[]
+              '
+          )
+
+          if [[ ${#package_versions[@]} -ne 1 || "${package_versions[0]}" != "$tag_version" ]]; then
+            echo "Tag $GITHUB_REF_NAME must match the single version shared by all publishable packages: ${package_versions[*]}" >&2
+            exit 1
+          fi
+
+      - name: Authenticate with crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish unpublished crates
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        run: |
+          mapfile -t publishable_packages < <(
+            cargo metadata --no-deps --format-version 1 |
+              jq -r '
+                .workspace_members as $members
+                | .packages[]
+                | select(.id as $id | $members | index($id))
+                | select(.publish != [])
+                | [.name, .version]
+                | @tsv
+              '
+          )
+
+          publish_args=()
+          response="$(mktemp)"
+          trap 'rm -f "$response"' EXIT
+
+          for package in "${publishable_packages[@]}"; do
+            IFS=$'\t' read -r package_name package_version <<< "$package"
+            status="$(
+              curl --silent --show-error --location \
+                --user-agent "${GITHUB_REPOSITORY} crates.io publisher" \
+                --output "$response" \
+                --write-out "%{http_code}" \
+                "https://crates.io/api/v1/crates/$package_name"
+            )"
+
+            case "$status" in
+              200)
+                if jq --exit-status --arg version "$package_version" \
+                  '.versions | any(.num == $version)' "$response" >/dev/null; then
+                  echo "$package_name $package_version is already published"
+                  continue
+                fi
+                ;;
+              404) ;;
+              *)
+                cat "$response" >&2
+                echo "crates.io returned HTTP $status for $package_name" >&2
+                exit 1
+                ;;
+            esac
+
+            publish_args+=(--package "$package_name")
+          done
+
+          if [[ ${#publish_args[@]} -eq 0 ]]; then
+            echo "All workspace packages are already published"
+            exit 0
+          fi
+
+          cargo publish "${publish_args[@]}"


### PR DESCRIPTION
## Summary
- publish workspace crates when a matching `v*` tag is pushed
- authenticate with crates.io Trusted Publishing instead of a long-lived secret
- reject tags that do not match the shared Cargo package version
- skip versions already on crates.io so partial workspace publishes can be resumed safely

## Verification
- `actionlint .github/workflows/publish-crates.yml`
- exercised matching and mismatched tag validation against `cargo metadata`
- exercised crates.io version selection against the live API
- confirmed the current package version is already published and the workflow exits successfully without republishing
